### PR TITLE
Remove alias table creation from afl-fuzz.c

### DIFF
--- a/AFLplusplus/src/afl-fuzz.c
+++ b/AFLplusplus/src/afl-fuzz.c
@@ -2631,6 +2631,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
           //create_alias_table(afl);
 
+           afl->reinit_table = 0;
         }
 
         do {


### PR DESCRIPTION
Dont need to create alias table as we dont use AFL's weighted random selection.