### PR TITLE
Heuristics

### DIFF
--- a/heuristics/heuristic_diff.py
+++ b/heuristics/heuristic_diff.py
@@ -46,7 +46,7 @@ def search_funcs(directory):
                         
     return funcs
 
-# Function that starts a subprocess, mostly used to check the git logs.
+# Function that starts a subprocess.
 def run_command(command):
     process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
     output = process.communicate()[0]

--- a/heuristics/heuristic_diff.py
+++ b/heuristics/heuristic_diff.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import subprocess
 from os.path import join
-from os import walk, chdir, getcwd
+from os import walk
 
 # Parses the command line arguments.
 def parse_args():

--- a/heuristics/heuristic_diff.py
+++ b/heuristics/heuristic_diff.py
@@ -14,26 +14,34 @@ def parse_args():
 # This function traverses a repo and returns all function names according to a pattern
 # that SHOULD represent most of the c type function declarations.
 def search_funcs(directory):
-    pattern = '^\s*(?:(?:inline|static)\s+){0,2}(?!else|typedef|return)\w+\s+\*?\s*(\w+)\s*\([^0]+\)\s*;?'
+    # This pattern finds a word that is followed up with a space and then a single quote.
+    pattern_func_name = r".*FunctionDecl.*\b(\w+)\b(?=\s*')"
+    #These are words that can't be in the ast dump.
+    forbidden_words = ['extern', 'implicit', 'invalid', '__']
 
     funcs = []
 
     for root, dirs, files in walk(directory):
         for file_str in files:
-            if file_str[-2:] == '.c' or file_str[-2] == '.h':
+            # Only find functions in .c files.
+            if file_str[-2:] == '.c':
                 file_path = join(root, file_str)
                 # Excludes testing function from function list.
                 if 'test' in file_path:
                     continue
-                file = open(file_path, 'r')
-                for line in file:
-                    match = re.search(pattern, line)
-                    if match:
-                        func_name = match.group(1)
-                        funcs.append((func_name, file_path))
+                ast_funcs = run_command('clang -Xclang -ast-dump -fsyntax-only ' + file_path + ' 2>/dev/null | grep FunctionDecl')
+                for line in ast_funcs.splitlines():
+                    found = False
+                    for word in forbidden_words:
+                        if word in line:
+                            found = True
+                        if not found:
+                            match = re.search(pattern_func_name, line)
+                            if match:
+                                func_name = match.group(1)
+                                print(func_name)
+                                funcs.append(func_name)
                         
-                
-
     return funcs
 
 # Function that starts a subprocess, mostly used to check the git logs.
@@ -48,12 +56,14 @@ def run_command(command):
 def main():
     args = parse_args()
     weighted_funcs = []
+    
     funcs = search_funcs(args.repo_path)
-    for func in funcs:
-        func_freq = run_command('git log --no-patch -L :' + func[0] + ':' + func[1] + ' | grep -c commit')
-        weighted_funcs.append((func[0], func_freq))
+    print(funcs)
+    # for func in funcs:
+    #     func_freq = run_command('cd ' + args.repo_path + '; git log --no-patch -L :' + func[0] + ':' + func[1] + ' | grep -c commit')
+    #     weighted_funcs.append((func[0], func_freq))
 
-    print(weighted_funcs)
+    # print(weighted_funcs)
 
 if __name__ == "__main__":
     main()

--- a/heuristics/heuristic_diff.py
+++ b/heuristics/heuristic_diff.py
@@ -9,6 +9,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description='This script returns a tuple of all function names in a git repository and the corresponding weights')
     parser.add_argument('repo_path', type=str,
                     help='Absolute path to git repository.')
+    parser.add_argument('output_path', type=bool,
+                    help='Enter either 1 if you want the file path in the output, otherwise 0.')
     return parser.parse_args()
 
 # This function traverses a repo and returns all function names according to a pattern
@@ -61,7 +63,10 @@ def main():
     funcs = search_funcs(args.repo_path)
     for func in funcs:
         func_freq = int(run_command('cd ' + args.repo_path + '; git log --no-patch -L :' + func[0] + ':' + func[1] + ' 2>/dev/null | grep -c commit').strip())
-        weighted_funcs.append((func[0], func_freq))
+        if args.file_path:
+            weighted_funcs.append((func[0], func_freq, func[1]))
+        else:
+            weighted_funcs.append((func[0], func_freq))
 
     # Filter all the functions without a commit history out, and sort the relevant funcs by commits.
     weighted_funcs = list(filter(lambda x: x[1] != 0, weighted_funcs))


### PR DESCRIPTION
These commits change the following things:

- Script now uses clang to browse ast to find function names.
- Added a flag that allows users to get the file path of the file where the function is found when outputting.
- All error messages of the scripts are redirected to /dev/null, cause they're not important to the user.